### PR TITLE
V3 restructure

### DIFF
--- a/temoa/temoa_model/temoa_myopic.py
+++ b/temoa/temoa_model/temoa_myopic.py
@@ -409,11 +409,9 @@ def myopic_db_generator_solver(self):
         # the database is ready. It is run via a temporary config file in
         # a perfect foresight fashion.
         # ---------------------------------------------------------------
-        new_config = os.path.join(os.getcwd(), "temoa_model", "config_sample") + new_myopic_name
-        if version < 3:
-            ifile = io.open(os.path.join(os.getcwd(), "temoa_model", "config_sample"), encoding='utf-8')
-        else:
-            ifile = open(os.path.join(os.getcwd(), "temoa_model", "config_sample"), encoding='utf-8')
+        new_config = self.options.file_location + new_myopic_name
+
+        ifile = open(self.options.file_location, encoding='utf-8')
 
         ofile = open(new_config, 'w')
         for line in ifile:
@@ -429,7 +427,7 @@ def myopic_db_generator_solver(self):
         ifile.close()
         ofile.close()
         executable_target = os.path.join(PROJECT_ROOT, 'main.py')  # temp fix to keep it all working....
-        os.system(f"python {executable_target} --config=temoa_model/config_sample" + new_myopic_name)
+        os.system(f"python {executable_target} --config={new_config}")
         # delete the temporary config file
         os.remove(new_config)
         if not self.options.KeepMyopicDBs:

--- a/temoa/temoa_model/temoa_run.py
+++ b/temoa/temoa_model/temoa_run.py
@@ -581,7 +581,8 @@ def parse_args():
     SE.write("Continue Operation? [Press enter to continue or CTRL+C to abort]\n")
     SE.flush()
     try:  # make compatible with Python 2.7 or 3
-        if os.path.join('temoa_model', 'config_sample_myopic') not in options.file_location:
+        # TODO:  this remnant is a horrible hack that needs to be changed to inspect for myopic mode vs. name matching
+        if 'config_sample_myopic' not in options.file_location:
             #
             input()  # Give the user a chance to confirm input
     except:

--- a/tests/test_full_runs.py
+++ b/tests/test_full_runs.py
@@ -81,7 +81,6 @@ def test_against_legacy_outputs(system_test_run):
 
 
 
-@pytest.mark.skip('not ready yet...')
 def test_myopic_utopia():
     """
     test the myopic functionality on Utopia.  We need to copy the source db to make the output and then erase
@@ -93,14 +92,14 @@ def test_myopic_utopia():
 
     """
     eps = 1e-3
-    config_file = pathlib.Path(PROJECT_ROOT, 'tests', 'testing_configs', 'config_utopia_myopic')
+    config_file = pathlib.Path(PROJECT_ROOT, 'tests', 'testing_configs', 'config_sample')
     # config_file = pathlib.Path(PROJECT_ROOT, 'tests', 'testing_configs', 'config_utopia_myopic')
     input_db = pathlib.Path(PROJECT_ROOT, 'tests', 'testing_data', 'temoa_utopia.sqlite')
-    output_db = pathlib.Path(PROJECT_ROOT, 'tests', 'testing_data', 'temoa_utopia_output_catcher.sqlite')
+    output_db = pathlib.Path(PROJECT_ROOT, 'tests', 'testing_outputs', 'temoa_utopia_output_catcher.sqlite')
     if os.path.isfile(output_db):
         os.remove(output_db)
     shutil.copy(input_db, output_db)  # put a new copy in place, ones that are used before fail.
-    model = TemoaModel()  # TODO: TemoaModel()
+    model = TemoaModel()
     temoa_solver = TemoaSolver(model, config_filename=config_file)
     for _ in temoa_solver.createAndSolve():
         pass

--- a/tests/testing_configs/config_sample
+++ b/tests/testing_configs/config_sample
@@ -8,19 +8,21 @@
 # Input File (Mandatory) 
 # Input can be a .sqlite or .dat file
 # Both relative path and absolute path are accepted
---input=testing_data/temoa_utopia.sqlite
+--input=testing_outputs/temoa_utopia_output_catcher.sqlite
 
 # Output File (Mandatory)
 # The output file must be a existing .sqlite file
---output=testing_data/temoa_utopia_output_catcher.sqlite
+--output=testing_outputs/temoa_utopia_output_catcher.sqlite
 
 # Scenario Name (Mandatory) 
 # This scenario name is used to store results within the output .sqlite file
---scenario=test_run
+--scenario=test_run_myopic
 
 # Path to folder containing input dataset (Mandatory)
 # This is the location where database files reside
---path_to_data=testing_data
+# TODO:  The use of the db in the "outputs" folder is a placeholder due to current functionality
+#        it should be changed to a "clean" source when code mods are done
+--path_to_data=testing_outputs
 
 # Solve Myopically (Optional)
 # Allows user to solve one model time period at a time, sequentially

--- a/tests/testing_outputs/.gitignore
+++ b/tests/testing_outputs/.gitignore
@@ -1,3 +1,5 @@
 # ignore the databases here.  They are just used to catch output
 
 *.sqlite
+*.dat
+*.xlsx


### PR DESCRIPTION
This commit adds / enables the functional regression test of the myopic mode in the v3 format.  This limited test compares some emission values captured from the original `energysystem` branch and checks those output values against a similar Utopia run in the v3 updated structure.  This partially covers testing of some of the changes in the codebase handle data tables differently due to Endogenous Retirement capability that has been added in the interim, even though *no* retirements are capable in the current input data (one reason to expect outputs to match.)  Future tests should expand on testing retirements and ensuring that capacities in distant myopic periods are correct.