### PR TITLE
Added Back MyopicBaseYear Table

### DIFF
--- a/temoa/temoa_model/myopic/hybrid_loader.py
+++ b/temoa/temoa_model/myopic/hybrid_loader.py
@@ -403,7 +403,7 @@ class HybridLoader:
                 case _:
                     raise ValueError(f'Component type unrecognized: {c}, {type(c)}')
 
-        M: TemoaModel = TemoaModel()  # for typing purposes only
+        M: TemoaModel = TemoaModel() # for typing purposes only
         cur = self.con.cursor()
 
         #   === TIME SETS ===
@@ -435,6 +435,16 @@ class HybridLoader:
         # time_season
         raw = cur.execute('SELECT t_season FROM main.time_season').fetchall()
         load_element(M.time_season, raw)
+
+        # myopic_base_year
+        if mi and self.table_exists('MyopicBaseyear'):
+            raw = cur.execute('SELECT year from main.MyopicBaseyear').fetchall()
+            # load as a singleton...
+            if not raw:
+                raise ValueError('No "year" found in MyopicBaseyear table.')
+            data[M.MyopicBaseyear.name] = {None: int(raw[0][0])}
+        elif mi:
+            raise ValueError('Running in myopic mode is not possible without MyopicBaseyear table.')
 
         #  === REGION SETS ===
 

--- a/temoa/temoa_model/temoa_model.py
+++ b/temoa/temoa_model/temoa_model.py
@@ -344,7 +344,7 @@ class TemoaModel(AbstractModel):
         M.StorageInit_rtv = Set(dimen=3, initialize=StorageInitIndices)
         M.StorageInitFrac = Param(M.StorageInit_rtv)
 
-        M.MyopicBaseyear = Param(default=0, mutable=True)
+        M.MyopicBaseyear = Param(default=0)
 
         ################################################
         #                 Model Variables              #

--- a/temoa/utilities/db_migration_1.sql
+++ b/temoa/utilities/db_migration_1.sql
@@ -5,8 +5,6 @@ ALTER TABLE technologies
 -- update the commodity flags.  REPLACE acts like "insert if not already there..."
 REPLACE INTO main.commodity_labels VALUES ('s', 'source commodity');
 
--- no longer used
-DROP TABLE IF EXISTS main.MyopicBaseyear;
 
 -- fix the FK assignment in OutputEmissions to ref the commodity table.  (the old ref was not a unique index)
 create table Output_Emissions_dg_tmp


### PR DESCRIPTION
After experimenting with alternatives for injesting the Myopic Base Year for costing purposes, decided that it is best (for now) to leave the table in and read the singleton value in it.  Note:  the table is optional and only required for myopic runs