### PR TITLE
Fixed Bug in Myopic Data Loading

### DIFF
--- a/temoa/temoa_model/hybrid_loader.py
+++ b/temoa/temoa_model/hybrid_loader.py
@@ -525,9 +525,10 @@ class HybridLoader:
             raw = cur.execute(
                 'SELECT region, tech, vintage, capacity FROM main.OutputNetCapacity '
                 ' WHERE period = ? '
+                ' AND scenario = ? '
                 'UNION '
                 '  SELECT region, tech, vintage, capacity FROM main.ExistingCapacity ',
-                (previous_period,),
+                (previous_period, self.config.scenario),
             ).fetchall()
         else:
             raw = cur.execute(


### PR DESCRIPTION
When pulling in existing capacity items from the previous iteration, there was a bug such that the scenario name wasn't being screened when querying the OutputNetCapacity table, so old results under different scenario were polluting inputs.  Fixed by adding scenario criteria to hybrid_loader.py