### PR TITLE
Updated Libraries

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ pyomo
 ipython
 matplotlib
 pandas
-numpy < 2.0  # currently, pyomo 6.7.3 is not yet updated to allow numpy 2.0.
+numpy
 joblib
 salib
 pydoe

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ anyio==4.4.0
     #   httpx
     #   jupyter-server
     #   starlette
-    #   watchfiles
 appdirs==1.4.4
     # via pint
 appnope==0.1.4
@@ -30,11 +29,11 @@ asttokens==2.4.1
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via
     #   jupyterlab-server
     #   sphinx
@@ -42,28 +41,26 @@ beautifulsoup4==4.12.3
     # via nbconvert
 bleach==6.1.0
     # via nbconvert
-certifi==2024.6.2
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via argon2-cffi-bindings
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via
-    #   typer
-    #   uvicorn
+    # via typer
 comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -73,31 +70,25 @@ deprecated==1.2.14
     # via -r requirements.in
 dill==0.3.8
     # via multiprocess
-dnspython==2.6.1
-    # via email-validator
 docutils==0.20.1
     # via
     #   pybtex-docutils
     #   sphinx
     #   sphinx-rtd-theme
     #   sphinxcontrib-bibtex
-email-validator==2.2.0
-    # via fastapi
 et-xmlfile==1.1.0
     # via openpyxl
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
+fastapi==0.112.2
     # via ixmp4
-fastapi-cli==0.0.4
-    # via fastapi
 fastjsonschema==2.20.0
     # via nbformat
 flexcache==0.3
     # via pint
 flexparser==0.3.1
     # via pint
-fonttools==4.53.0
+fonttools==4.53.1
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -105,12 +96,10 @@ graphviz==0.20.3
     # via -r requirements.in
 gravis==0.1.0
     # via -r requirements.in
-gurobipy==11.0.2
+gurobipy==11.0.3
     # via -r requirements.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
+    # via httpcore
 h2==4.1.0
     # via httpx
 highspy==1.7.2
@@ -119,21 +108,17 @@ hpack==4.0.0
     # via h2
 httpcore==1.0.5
     # via httpx
-httptools==0.6.1
-    # via uvicorn
-httpx[http2]==0.27.0
+httpx[http2]==0.27.2
     # via
-    #   fastapi
     #   ixmp4
     #   jupyterlab
 hyperframe==6.0.1
     # via h2
 iam-units==2023.9.12
     # via pyam-iamc
-idna==3.7
+idna==3.8
     # via
     #   anyio
-    #   email-validator
     #   httpx
     #   jsonschema
     #   requests
@@ -147,7 +132,6 @@ ipykernel==6.29.5
     #   jupyter
     #   jupyter-console
     #   jupyterlab
-    #   qtconsole
 ipython==8.26.0
     # via
     #   -r requirements.in
@@ -156,17 +140,16 @@ ipython==8.26.0
     #   jupyter-console
 ipython-genutils==0.2.0
     # via jupyter-contrib-nbextensions
-ipywidgets==8.1.3
+ipywidgets==8.1.5
     # via jupyter
 isoduration==20.11.0
     # via jsonschema
-ixmp4==0.9.1
+ixmp4==0.9.2
     # via pyam-iamc
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
-    #   fastapi
     #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server
@@ -178,14 +161,14 @@ json5==0.9.25
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
-jsonschema[format-nongpl]==4.22.0
+jsonschema[format-nongpl]==4.23.0
     # via
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
 jsonschema-specifications==2023.12.1
     # via jsonschema
-jupyter==1.0.0
+jupyter==1.1.0
     # via -r requirements.in
 jupyter-client==8.6.2
     # via
@@ -193,7 +176,6 @@ jupyter-client==8.6.2
     #   jupyter-console
     #   jupyter-server
     #   nbclient
-    #   qtconsole
 jupyter-console==6.6.3
     # via jupyter
 jupyter-contrib-core==0.4.2
@@ -215,7 +197,6 @@ jupyter-core==5.7.2
     #   nbclient
     #   nbconvert
     #   nbformat
-    #   qtconsole
 jupyter-events==0.10.0
     # via jupyter-server
 jupyter-highlight-selected-word==0.2.0
@@ -224,7 +205,7 @@ jupyter-lsp==2.2.5
     # via jupyterlab
 jupyter-nbextensions-configurator==0.6.4
     # via jupyter-contrib-nbextensions
-jupyter-server==2.14.1
+jupyter-server==2.14.2
     # via
     #   jupyter-lsp
     #   jupyter-nbextensions-configurator
@@ -234,21 +215,23 @@ jupyter-server==2.14.1
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.2.3
-    # via notebook
+jupyterlab==4.2.5
+    # via
+    #   jupyter
+    #   notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.27.2
+jupyterlab-server==2.27.3
     # via
     #   jupyterlab
     #   notebook
-jupyterlab-widgets==3.0.11
+jupyterlab-widgets==3.0.13
     # via ipywidgets
 kiwisolver==1.4.5
     # via matplotlib
 latexcodec==3.0.0
     # via pybtex
-lxml==5.2.2
+lxml==5.3.0
     # via jupyter-contrib-nbextensions
 mako==1.3.5
     # via alembic
@@ -259,7 +242,7 @@ markupsafe==2.1.5
     #   jinja2
     #   mako
     #   nbconvert
-matplotlib==3.9.0
+matplotlib==3.9.2
     # via
     #   -r requirements.in
     #   pyam-iamc
@@ -277,7 +260,7 @@ multimethod==1.10
     # via pandera
 multiprocess==0.70.16
     # via salib
-mypy==1.10.1
+mypy==1.11.2
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via
@@ -301,7 +284,7 @@ networkx==3.3
     # via -r requirements.in
 nose==1.3.7
     # via pyutilib
-notebook==7.2.1
+notebook==7.2.2
     # via
     #   jupyter
     #   jupyter-contrib-core
@@ -311,7 +294,7 @@ notebook-shim==0.2.4
     # via
     #   jupyterlab
     #   notebook
-numpy==1.26.4
+numpy==2.1.0
     # via
     #   -r requirements.in
     #   contourpy
@@ -330,8 +313,6 @@ openpyxl==3.1.5
     #   -r requirements.in
     #   ixmp4
     #   pyam-iamc
-orjson==3.10.6
-    # via fastapi
 overrides==7.7.0
     # via jupyter-server
 packaging==24.1
@@ -345,8 +326,6 @@ packaging==24.1
     #   pandera
     #   plotly
     #   pytest
-    #   qtconsole
-    #   qtpy
     #   sphinx
 pandas==2.2.2
     # via
@@ -356,7 +335,7 @@ pandas==2.2.2
     #   pyam-iamc
     #   salib
     #   seaborn
-pandera==0.20.1
+pandera==0.20.3
     # via ixmp4
 pandocfilters==1.5.1
     # via nbconvert
@@ -366,13 +345,13 @@ pexpect==4.9.0
     # via ipython
 pillow==10.4.0
     # via matplotlib
-pint==0.24.1
+pint==0.24.3
     # via
     #   iam-units
     #   pyam-iamc
 platformdirs==4.2.2
     # via jupyter-core
-plotly==5.22.0
+plotly==5.24.0
     # via -r requirements.in
 pluggy==1.5.0
     # via pytest
@@ -394,9 +373,9 @@ ptyprocess==0.7.0
     # via
     #   pexpect
     #   terminado
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyam-iamc==2.2.3
+pyam-iamc==2.2.4
     # via -r requirements.in
 pybtex==0.24.0
     # via
@@ -406,15 +385,15 @@ pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
 pycparser==2.22
     # via cffi
-pydantic==2.8.0
+pydantic==2.8.2
     # via
     #   fastapi
     #   ixmp4
     #   pandera
     #   pydantic-settings
-pydantic-core==2.20.0
+pydantic-core==2.20.1
     # via pydantic
-pydantic-settings==2.3.4
+pydantic-settings==2.4.0
     # via ixmp4
 pydoe==0.3.8
     # via -r requirements.in
@@ -423,16 +402,15 @@ pygments==2.18.0
     #   ipython
     #   jupyter-console
     #   nbconvert
-    #   qtconsole
     #   rich
     #   sphinx
-pyjwt==2.8.0
+pyjwt==2.9.0
     # via ixmp4
-pyomo==6.7.3
+pyomo==6.8.0
     # via -r requirements.in
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
-pytest==8.2.2
+pytest==8.3.2
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
@@ -444,33 +422,24 @@ python-dotenv==1.0.1
     # via
     #   ixmp4
     #   pydantic-settings
-    #   uvicorn
 python-json-logger==2.0.7
     # via jupyter-events
-python-multipart==0.0.9
-    # via fastapi
 pytz==2024.1
     # via pandas
 pyutilib==6.0.0
     # via -r requirements.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   jupyter-events
     #   jupyter-nbextensions-configurator
     #   pyam-iamc
     #   pybtex
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-console
     #   jupyter-server
-    #   qtconsole
-qtconsole==5.5.2
-    # via jupyter
-qtpy==2.4.1
-    # via qtconsole
 referencing==0.35.1
     # via
     #   jsonschema
@@ -489,17 +458,17 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rich==13.7.1
+rich==13.8.0
     # via
     #   ixmp4
     #   typer
-rpds-py==0.18.1
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
-salib==1.5.0
+salib==1.5.1
     # via -r requirements.in
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   -r requirements.in
     #   pyam-iamc
@@ -527,9 +496,9 @@ sniffio==1.3.1
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
-sphinx==7.3.7
+sphinx==7.4.7
     # via
     #   -r requirements.in
     #   sphinx-rtd-theme
@@ -537,13 +506,13 @@ sphinx==7.3.7
     #   sphinxcontrib-jquery
 sphinx-rtd-theme==2.0.0
     # via -r requirements.in
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-bibtex==2.6.2
     # via -r requirements.in
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via
     #   -r requirements.in
     #   sphinx
@@ -551,13 +520,13 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via
     #   -r requirements.in
     #   sphinx
-sqlalchemy[mypy]==2.0.31
+sqlalchemy[mypy]==2.0.32
     # via
     #   alembic
     #   ixmp4
@@ -567,11 +536,11 @@ sqlalchemy-utils==0.41.2
     # via ixmp4
 stack-data==0.6.3
     # via ipython
-starlette==0.37.2
+starlette==0.38.2
     # via fastapi
 tabulate==0.9.0
     # via -r requirements.in
-tenacity==8.4.2
+tenacity==9.0.0
     # via plotly
 terminado==0.18.1
     # via
@@ -611,14 +580,11 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-    #   qtconsole
 typeguard==4.3.0
     # via pandera
-typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   ixmp4
-types-python-dateutil==2.9.0.20240316
+typer==0.12.5
+    # via ixmp4
+types-python-dateutil==2.9.0.20240821
     # via arrow
 typing-extensions==4.12.2
     # via
@@ -639,21 +605,13 @@ typing-inspect==0.9.0
     # via pandera
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.2
     # via requests
-uvicorn[standard]==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-webcolors==24.6.0
+webcolors==24.8.0
     # via jsonschema
 webencodings==0.5.1
     # via
@@ -661,9 +619,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-websockets==12.0
-    # via uvicorn
-widgetsnbextension==4.0.11
+widgetsnbextension==4.0.13
     # via ipywidgets
 wquantiles==0.6
     # via pyam-iamc


### PR DESCRIPTION
This PR "releases the hold" on updating Numpy and subsequently, Pyomo

Pyomo is now numpy 2.0 compatible with the latest release, so this PR allows both to update.  All internal tests pass on MacOS.  Noted slight decrease in testing time ~10%, so perhaps a performance upgrade overall.

This commit also allows many other library updates
