### PR TITLE
add temoa_alpha to CI monitoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
     push:
-      branches: [ "main" ]
+      branches: [ "main",  "temoa_alpha" ]
     pull_request:
-      branches: [ "main" ]
+      branches: [ "main", "temoa_alpha" ]
 
 jobs:
   test:


### PR DESCRIPTION
sets up CI to run on temoa_alpha branch in addition to the main branch

License: GPLv2