### PR TITLE
Temp annualised demands

### DIFF
--- a/temoa/temoa_model/hybrid_loader.py
+++ b/temoa/temoa_model/hybrid_loader.py
@@ -1180,6 +1180,7 @@ class HybridLoader:
         M: TemoaModel = TemoaModel()  # for typing
         param_idx_sets = {
             M.CostInvest.name: M.CostInvest_rtv.name,
+            M.Demand.name: M.DemandConstraint_rpc.name,
             M.EmissionLimit.name: M.EmissionLimitConstraint_rpe.name,
             M.MaxActivity.name: M.MaxActivityConstraint_rpt.name,
             M.MaxActivityGroup.name: M.MaxActivityGroup_rpg.name,

--- a/temoa/temoa_model/table_data_puller.py
+++ b/temoa/temoa_model/table_data_puller.py
@@ -179,8 +179,12 @@ def poll_flow_results(M: TemoaModel, epsilon=1e-5) -> dict[FI, dict[FlowType, fl
     for r, p, i, t, v, o in M.V_FlowOutAnnual:
         for s in M.time_season:
             for d in M.time_of_day:
+                if t in M.tech_demand:
+                    distribution = value(M.DemandSpecificDistribution[r, s, d, o])
+                else:
+                    distribution = value(M.SegFrac[s, d])
                 fi = FI(r, p, s, d, i, t, v, o)
-                flow = value(M.V_FlowOutAnnual[r, p, i, t, v, o]) * value(M.SegFrac[s, d])
+                flow = value(M.V_FlowOutAnnual[r, p, i, t, v, o]) * distribution
                 if abs(flow) < epsilon:
                     continue
                 res[fi][FlowType.OUT] = flow

--- a/temoa/temoa_model/temoa_initialize.py
+++ b/temoa/temoa_model/temoa_initialize.py
@@ -107,19 +107,19 @@ def CommodityBalanceConstraintErrorCheckAnnual(vflow_out, vflow_in, r, p, c):
         raise Exception(msg.format(r, c, p, flow_in_expr.getvalue()))
 
 
-def DemandConstraintErrorCheck(supply, r, p, s, d, dem):
+def DemandConstraintErrorCheck(supply, r, p, dem):
     # note:  if a pyomo equation simplifies to an int, there are no variables in it, which
     #        is an indicator of a problem
     if isinstance(supply, int):
         msg = (
-            "Error: Demand '{}' for ({}, {}, {}) unable to be met by any "
+            "Error: Demand '{}' for ({}, {}) unable to be met by any "
             'technology.\n\tPossible reasons:\n'
             ' - Is the Efficiency parameter missing an entry for this demand?\n'
             ' - Does a tech that satisfies this demand need a longer '
             'LifetimeProcess?\n'
         )
         logger.error(msg)
-        raise Exception(msg.format(r, dem, p, s, d))
+        raise Exception(msg.format(dem, r, p))
 
 
 def validate_time(M: 'TemoaModel'):
@@ -342,6 +342,7 @@ def CreateDemands(M: 'TemoaModel'):
     specify the distribution, or not.  No in-between.
      5. Validate that the per-demand distributions sum to 1.
     """
+    print([rpc for rpc in M.DemandConstraint_rpc])
     logger.debug('Started creating demand distributions in CreateDemands()')
 
     # Step 0: some setup for a couple of reusable items
@@ -628,6 +629,11 @@ def CreateSparseDicts(M: 'TemoaModel'):
 
         if t in M.tech_flex:
             M.flex_commodities.add(o)
+
+        # All demand technologies must be annual technologies
+        if o in M.commodity_demand and t not in M.tech_demand:
+            M.tech_annual.add(t)
+            M.tech_demand.add(t)
 
         # Add in the period (p) index, since it's not included in the efficiency
         # table.
@@ -1046,7 +1052,7 @@ def CapacityConstraintIndices(M: 'TemoaModel'):
     capacity_indices = set(
         (r, p, s, d, t, v)
         for r, p, t, v in M.activeActivity_rptv
-        if t not in M.tech_annual
+        if (t not in M.tech_annual or t in M.tech_demand)
         if t not in M.tech_uncap
         for s in M.time_season
         for d in M.time_of_day
@@ -1074,7 +1080,7 @@ def CapacityAnnualConstraintIndices(M: 'TemoaModel'):
     capacity_indices = set(
         (r, p, t, v)
         for r, p, t, v in M.activeActivity_rptv
-        if t in M.tech_annual
+        if t in M.tech_annual and t not in M.tech_demand
         if t not in M.tech_uncap
     )
 
@@ -1088,79 +1094,68 @@ def CapacityAnnualConstraintIndices(M: 'TemoaModel'):
 # ---------------------------------------------------------------
 
 
-def DemandActivityConstraintIndices(M: 'TemoaModel'):
-    """\
-This function returns a set of sparse indices that are used in the
-DemandActivity constraint. It returns a tuple of the form:
-(p,s,d,t,v,dem,first_s,first_d) where "dem" is a demand commodity, and "first_s"
-and "first_d" are the reference season and time-of-day, respectively used to
-ensure demand activity remains consistent across time slices.
-"""
+# def DemandActivityConstraintIndices(M: 'TemoaModel'):
+#     """\
+# This function returns a set of sparse indices that are used in the
+# DemandActivity constraint. It returns a tuple of the form:
+# (p,s,d,t,v,dem,first_s,first_d) where "dem" is a demand commodity, and "first_s"
+# and "first_d" are the reference season and time-of-day, respectively used to
+# ensure demand activity remains consistent across time slices.
+# """
 
-    # needed data structures...
-    # the count of techs that supply a commodity
-    suppliers = defaultdict(set)
-    # (region, demand): (season, tod)  # the goal of the exercise!
-    anchor_season_tod = {}
-    # (region, demand): (period, tech, vintage) # the viable tech and vintage per region, demand
-    viable_tech_vintage = defaultdict(list)
+#     # needed data structures...
+#     # the count of techs that supply a commodity
+#     suppliers = defaultdict(set)
+#     # (region, demand): (season, tod)  # the goal of the exercise!
+#     anchor_season_tod = {}
+#     # (region, demand): (period, tech, vintage) # the viable tech and vintage per region, demand
+#     viable_tech_vintage = defaultdict(list)
 
-    # start the loop over possible combos
-    for r, p, t, v, dem in M.ProcessInputsByOutput:
-        # we aren't concerned with non-demand commodities or annual techs
-        if dem not in M.commodity_demand or t in M.tech_annual:
-            continue
-        # capture the (p, t, v) in case we need to act on it
-        viable_tech_vintage[r, dem].append((p, t, v))
-        suppliers[dem].add(t)  # one more recognized supplier
-        if len(suppliers[dem]) > 1:
-            # We need to act on (build) for this region-demand, put in a placeholder
-            anchor_season_tod[r, dem] = None
+#     # start the loop over possible combos
+#     for r, p, t, v, dem in M.ProcessInputsByOutput:
+#         # we aren't concerned with non-demand commodities or annual techs
+#         if dem not in M.commodity_demand or t in M.tech_annual:
+#             continue
+#         # capture the (p, t, v) in case we need to act on it
+#         viable_tech_vintage[r, dem].append((p, t, v))
+#         suppliers[dem].add(t)  # one more recognized supplier
+#         if len(suppliers[dem]) > 1:
+#             # We need to act on (build) for this region-demand, put in a placeholder
+#             anchor_season_tod[r, dem] = None
 
-    # Find the first timestep of the year where the demand is appreciably sized:
-    #   appreciable = not so small that we get into numerical instability when applying small multipliers
-    appreciable_size = 0.0001
+#     # Find the first timestep of the year where the demand is appreciably sized:
+#     #   appreciable = not so small that we get into numerical instability when applying small multipliers
+#     appreciable_size = 0.0001
 
-    for r, dem in anchor_season_tod:
-        found_flag = False
-        s0, d0 = None, None
-        for s0, d0 in ((ss, dd) for ss in M.time_season for dd in M.time_of_day):
-            if (r, s0, d0, dem) in M.DemandSpecificDistribution.sparse_iterkeys():
-                if value(M.DemandSpecificDistribution[(r, s0, d0, dem)]) >= appreciable_size:
-                    found_flag = True
-                    break  # we have one with some value associated
-        found = 'found' if found_flag else 'not found'
-        # set it.  If nothing was found the first indices should work just fine...
-        anchor_season_tod[r, dem] = (s0, d0)
-        logger.debug(
-            'Using season/tod: %s, %s for commodity %s in region %s which was %s in DSD '
-            'to set DemandActivity baseline',
-            s0,
-            d0,
-            dem,
-            r,
-            found,
-        )
+#     for r, dem in anchor_season_tod:
+#         found_flag = False
+#         s0, d0 = None, None
+#         for s0, d0 in ((ss, dd) for ss in M.time_season for dd in M.time_of_day):
+#             if (r, s0, d0, dem) in M.DemandSpecificDistribution.sparse_iterkeys():
+#                 if value(M.DemandSpecificDistribution[(r, s0, d0, dem)]) >= appreciable_size:
+#                     found_flag = True
+#                     break  # we have one with some value associated
+#         found = 'found' if found_flag else 'not found'
+#         # set it.  If nothing was found the first indices should work just fine...
+#         anchor_season_tod[r, dem] = (s0, d0)
+#         logger.debug(
+#             'Using season/tod: %s, %s for commodity %s in region %s which was %s in DSD '
+#             'to set DemandActivity baseline',
+#             s0,
+#             d0,
+#             dem,
+#             r,
+#             found,
+#         )
 
-    # Start yielding the constraint indices
-    for r, dem in anchor_season_tod:
-        s0, d0 = anchor_season_tod[r, dem]
-        for p, t, v in viable_tech_vintage[r, dem]:
-            for s in M.time_season:
-                for d in M.time_of_day:
-                    if s != s0 or d != d0:
-                        yield r, p, s, d, t, v, dem, s0, d0
-
-
-def DemandConstraintIndices(M: 'TemoaModel'):
-    indices = set(
-        (r, p, s, d, dem)
-        for r, p, dem in M.Demand.sparse_iterkeys()
-        for s in M.time_season
-        for d in M.time_of_day
-    )
-
-    return indices
+#     # Start yielding the constraint indices
+#     for r, dem in anchor_season_tod:
+#         s0, d0 = anchor_season_tod[r, dem]
+#         for p, t, v in viable_tech_vintage[r, dem]:
+#             for s in M.time_season:
+#                 for d in M.time_of_day:
+#                     if s != s0 or d != d0:
+#                         yield r, p, s, d, t, v, dem, s0, d0
 
 
 def BaseloadDiurnalConstraintIndices(M: 'TemoaModel'):

--- a/temoa/temoa_model/temoa_model.py
+++ b/temoa/temoa_model/temoa_model.py
@@ -147,6 +147,7 @@ class TemoaModel(AbstractModel):
         M.tech_all = Set(initialize=M.tech_resource | M.tech_production, validate=no_slash_or_pipe)
         M.tech_baseload = Set(within=M.tech_all)
         M.tech_annual = Set(within=M.tech_all)
+        M.tech_demand = Set(within=M.tech_annual)
         # annual storage not supported in Storage constraint or TableWriter, so exclude from domain
         M.tech_storage = Set(within=M.tech_all - M.tech_annual)
         M.tech_reserve = Set(within=M.tech_all)
@@ -233,7 +234,10 @@ class TemoaModel(AbstractModel):
             M.regions, M.time_season, M.time_of_day, M.commodity_demand, mutable=True, default=0
         )
 
-        M.Demand = Param(M.regions, M.time_optimize, M.commodity_demand)
+        M.DemandConstraint_rpc = Set(within=M.regions * M.time_optimize * M.commodity_demand)
+        M.Demand = Param(M.DemandConstraint_rpc)
+
+        # M.Demand = Param(M.regions * M.time_optimize * M.commodity_demand)
         M.initialize_Demands = BuildAction(rule=CreateDemands)
 
         M.ResourceConstraint_rpr = Set(within=M.regions * M.time_optimize * M.commodity_physical)
@@ -560,15 +564,16 @@ class TemoaModel(AbstractModel):
         # Declare core model constraints that ensure proper system functioning
         # In driving order, starting with the need to meet end-use demands
 
-        M.DemandConstraint_rpsdc = Set(dimen=5, initialize=DemandConstraintIndices)
-        M.DemandConstraint = Constraint(M.DemandConstraint_rpsdc, rule=Demand_Constraint)
+        M.DemandConstraint = Constraint(
+            M.DemandConstraint_rpc, rule=Demand_Constraint
+        )
 
-        M.DemandActivityConstraint_rpsdtv_dem_s0d0 = Set(
-            dimen=9, initialize=DemandActivityConstraintIndices
-        )
-        M.DemandActivityConstraint = Constraint(
-            M.DemandActivityConstraint_rpsdtv_dem_s0d0, rule=DemandActivity_Constraint
-        )
+        # M.DemandActivityConstraint_rpsdtv_dem_s0d0 = Set(
+        #     dimen=9, initialize=DemandActivityConstraintIndices
+        # )
+        # M.DemandActivityConstraint = Constraint(
+        #     M.DemandActivityConstraint_rpsdtv_dem_s0d0, rule=DemandActivity_Constraint
+        # )
 
         M.CommodityBalanceConstraint_rpsdc = Set(
             dimen=5, initialize=CommodityBalanceConstraintIndices

--- a/temoa/temoa_model/temoa_rules.py
+++ b/temoa/temoa_model/temoa_rules.py
@@ -100,11 +100,20 @@ def Capacity_Constraint(M: 'TemoaModel', r, p, s, d, t, v):
     # The expressions below are defined in-line to minimize the amount of
     # expression cloning taking place with Pyomo.
 
-    useful_activity = sum(
-        M.V_FlowOut[r, p, s, d, S_i, t, v, S_o]
-        for S_i in M.processInputs[r, p, t, v]
-        for S_o in M.ProcessOutputsByInput[r, p, t, v, S_i]
-    )
+    if t in M.tech_demand:
+        useful_activity = sum(
+            M.DemandSpecificDistribution[r, s, d, S_o]
+            * M.V_FlowOutAnnual[r, p, S_i, t, v, S_o]
+            for S_i in M.processInputs[r, p, t, v]
+            for S_o in M.ProcessOutputsByInput[r, p, t, v, S_i]
+        )
+    else:
+        useful_activity = sum(
+            M.V_FlowOut[r, p, s, d, S_i, t, v, S_o]
+            for S_i in M.processInputs[r, p, t, v]
+            for S_o in M.ProcessOutputsByInput[r, p, t, v, S_i]
+        )
+    
     if (r, s, d, t, v) in M.CapacityFactorProcess:
         # use the data provided
         capacity = value(M.CapacityFactorProcess[r, s, d, t, v])
@@ -597,7 +606,7 @@ def PeriodCost_rule(M: 'TemoaModel', p):
 # ---------------------------------------------------------------
 
 
-def Demand_Constraint(M: 'TemoaModel', r, p, s, d, dem):
+def Demand_Constraint(M: 'TemoaModel', r, p, dem):
     r"""
 
     The Demand constraint drives the model.  This constraint ensures that supply at
@@ -621,24 +630,17 @@ def Demand_Constraint(M: 'TemoaModel', r, p, s, d, dem):
     could satisfy both an end-use and internal system demand, then the output from
     :math:`\textbf{FO}` and :math:`\textbf{FOA}` would be double counted."""
 
-    supply = sum(
-        M.V_FlowOut[r, p, s, d, S_i, S_t, S_v, dem]
-        for S_t, S_v in M.commodityUStreamProcess[r, p, dem]
-        if S_t not in M.tech_annual
-        for S_i in M.ProcessInputsByOutput[r, p, S_t, S_v, dem]
-    )
-
     supply_annual = sum(
         M.V_FlowOutAnnual[r, p, S_i, S_t, S_v, dem]
         for S_t, S_v in M.commodityUStreamProcess[r, p, dem]
         if S_t in M.tech_annual
         for S_i in M.ProcessInputsByOutput[r, p, S_t, S_v, dem]
-    ) * value(M.SegFrac[s, d])
+    )
 
-    DemandConstraintErrorCheck(supply + supply_annual, r, p, s, d, dem)
+    DemandConstraintErrorCheck(supply_annual, r, p, dem)
 
     expr = (
-        supply + supply_annual == M.Demand[r, p, dem] * M.DemandSpecificDistribution[r, s, d, dem]
+        supply_annual == M.Demand[r, p, dem]
     )
 
     return expr
@@ -789,7 +791,15 @@ def CommodityBalance_Constraint(M: 'TemoaModel', r, p, s, d, c):
     vflow_in_ToNonStorageAnnual = value(M.SegFrac[s, d]) * sum(
         M.V_FlowOutAnnual[r, p, c, S_t, S_v, S_o] / value(M.Efficiency[r, c, S_t, S_v, S_o])
         for S_t, S_v in M.commodityDStreamProcess[r, p, c]
-        if S_t not in M.tech_storage and S_t in M.tech_annual
+        if S_t in M.tech_annual and S_t not in M.tech_demand
+        for S_o in M.ProcessOutputsByInput[r, p, S_t, S_v, c]
+    )
+
+    vflow_in_ToDemand = sum(
+        value(M.DemandSpecificDistribution[r, s, d, S_o])
+        * M.V_FlowOutAnnual[r, p, c, S_t, S_v, S_o] / value(M.Efficiency[r, c, S_t, S_v, S_o])
+        for S_t, S_v in M.commodityDStreamProcess[r, p, c]
+        if S_t in M.tech_demand
         for S_o in M.ProcessOutputsByInput[r, p, S_t, S_v, c]
     )
 
@@ -841,6 +851,8 @@ def CommodityBalance_Constraint(M: 'TemoaModel', r, p, s, d, c):
         vflow_in_ToStorage
         + vflow_in_ToNonStorage
         + vflow_in_ToNonStorageAnnual
+        + vflow_in_ToDemand
+        + vflow_in_ToDemand
         + interregional_exports
         + v_out_excess,
         r,
@@ -855,6 +867,7 @@ def CommodityBalance_Constraint(M: 'TemoaModel', r, p, s, d, c):
         == vflow_in_ToStorage
         + vflow_in_ToNonStorage
         + vflow_in_ToNonStorageAnnual
+        + vflow_in_ToDemand
         + interregional_exports
         + v_out_excess
     )
@@ -2982,18 +2995,52 @@ def LinkedEmissionsTech_Constraint(M: 'TemoaModel', r, p, s, d, t, v, e):
     the primary region corresponds to the linked technology as well. The lifetimes
     of the primary and linked technologies should be specified and identical.
     """
+
+    if t in M.tech_demand:
+        primary_flow = sum(
+            M.DemandSpecificDistribution[r, s, d, S_o]
+            * M.V_FlowOutAnnual[r, p, S_i, t, v, S_o]
+            * value(M.EmissionActivity[r, e, S_i, t, v, S_o])
+            for S_i in M.processInputs[r, p, t, v]
+            for S_o in M.ProcessOutputsByInput[r, p, t, v, S_i]
+        )
+    elif t in M.tech_annual:
+        primary_flow = sum(
+            M.SegFrac[s, d]
+            * M.V_FlowOutAnnual[r, p, S_i, t, v, S_o]
+            * value(M.EmissionActivity[r, e, S_i, t, v, S_o])
+            for S_i in M.processInputs[r, p, t, v]
+            for S_o in M.ProcessOutputsByInput[r, p, t, v, S_i]
+        )
+    else:
+        primary_flow = sum(
+            M.V_FlowOut[r, p, s, d, S_i, t, v, S_o]
+            * value(M.EmissionActivity[r, e, S_i, t, v, S_o])
+            for S_i in M.processInputs[r, p, t, v]
+            for S_o in M.ProcessOutputsByInput[r, p, t, v, S_i]
+        )
+
     linked_t = M.LinkedTechs[r, t, e]
 
-    primary_flow = sum(
-        M.V_FlowOut[r, p, s, d, S_i, t, v, S_o] * M.EmissionActivity[r, e, S_i, t, v, S_o]
-        for S_i in M.processInputs[r, p, t, v]
-        for S_o in M.ProcessOutputsByInput[r, p, t, v, S_i]
-    )
-
-    linked_flow = sum(
-        M.V_FlowOut[r, p, s, d, S_i, linked_t, v, S_o]
-        for S_i in M.processInputs[r, p, linked_t, v]
-        for S_o in M.ProcessOutputsByInput[r, p, linked_t, v, S_i]
-    )
+    if linked_t in M.tech_demand:
+        linked_flow = sum(
+            M.DemandSpecificDistribution[r, s, d, S_o]
+            * M.V_FlowOutAnnual[r, p, S_i, linked_t, v, S_o]
+            for S_i in M.processInputs[r, p, linked_t, v]
+            for S_o in M.ProcessOutputsByInput[r, p, linked_t, v, S_i]
+        )
+    elif linked_t in M.tech_annual:
+        linked_flow = sum(
+            M.SegFrac[p, s, d]
+            * M.V_FlowOutAnnual[r, p, S_i, linked_t, v, S_o]
+            for S_i in M.processInputs[r, p, linked_t, v]
+            for S_o in M.ProcessOutputsByInput[r, p, linked_t, v, S_i]
+        )
+    else:
+        linked_flow = sum(
+            M.V_FlowOut[r, p, s, d, S_i, linked_t, v, S_o]
+            for S_i in M.processInputs[r, p, linked_t, v]
+            for S_o in M.ProcessOutputsByInput[r, p, linked_t, v, S_i]
+        )
 
     return -primary_flow == linked_flow

--- a/tests/legacy_test_values.py
+++ b/tests/legacy_test_values.py
@@ -44,14 +44,14 @@ test_vals = {
         ExpectedVals.OBJ_VALUE: 491977.7000753,
         ExpectedVals.EFF_DOMAIN_SIZE: 30720,
         ExpectedVals.EFF_INDEX_SIZE: 74,
-        ExpectedVals.CONSTR_COUNT: 2826,
-        ExpectedVals.VAR_COUNT: 1904,
+        ExpectedVals.CONSTR_COUNT: 2322,
+        ExpectedVals.VAR_COUNT: 1484,
     },
     'utopia': {
         ExpectedVals.OBJ_VALUE: 36535.631200,
         ExpectedVals.EFF_DOMAIN_SIZE: 12312,
         ExpectedVals.EFF_INDEX_SIZE: 64,
-        ExpectedVals.CONSTR_COUNT: 1452,  # reduced 3/27:  unlim_cap techs now employed
-        ExpectedVals.VAR_COUNT: 1055,  # reduced 3/27:  unlim_cap techs now employed
+        ExpectedVals.CONSTR_COUNT: 1227,  # reduced 3/27:  unlim_cap techs now employed
+        ExpectedVals.VAR_COUNT: 855,  # reduced 3/27:  unlim_cap techs now employed
     },
 }

--- a/tests/legacy_test_values.py
+++ b/tests/legacy_test_values.py
@@ -44,14 +44,14 @@ test_vals = {
         ExpectedVals.OBJ_VALUE: 491977.7000753,
         ExpectedVals.EFF_DOMAIN_SIZE: 30720,
         ExpectedVals.EFF_INDEX_SIZE: 74,
-        ExpectedVals.CONSTR_COUNT: 2322,
-        ExpectedVals.VAR_COUNT: 1484,
+        ExpectedVals.CONSTR_COUNT: 2826,
+        ExpectedVals.VAR_COUNT: 1904,
     },
     'utopia': {
         ExpectedVals.OBJ_VALUE: 36535.631200,
         ExpectedVals.EFF_DOMAIN_SIZE: 12312,
         ExpectedVals.EFF_INDEX_SIZE: 64,
-        ExpectedVals.CONSTR_COUNT: 1227,  # reduced 3/27:  unlim_cap techs now employed
-        ExpectedVals.VAR_COUNT: 855,  # reduced 3/27:  unlim_cap techs now employed
+        ExpectedVals.CONSTR_COUNT: 1452,  # reduced 3/27:  unlim_cap techs now employed
+        ExpectedVals.VAR_COUNT: 1055,  # reduced 3/27:  unlim_cap techs now employed
     },
 }

--- a/tests/testing_configs/config_emissions.toml
+++ b/tests/testing_configs/config_emissions.toml
@@ -2,8 +2,8 @@
 scenario = "test run"
 scenario_mode = "perfect_foresight"
 
-input_database = "testing_outputs/emissions.sqlite"
-output_database = "testing_outputs/emissions.sqlite"
+input_database = "tests/testing_outputs/emissions.sqlite"
+output_database = "tests/testing_outputs/emissions.sqlite"
 neos = false
 
 # solver

--- a/tests/testing_configs/config_link_test.toml
+++ b/tests/testing_configs/config_link_test.toml
@@ -18,13 +18,13 @@ scenario = "test_linked_tech"
 scenario_mode = "perfect_foresight"
 
 # Input database (Mandatory)
-input_database = "testing_outputs/simple_linked_tech.sqlite"
+input_database = "tests/testing_outputs/simple_linked_tech.sqlite"
 
 # Output file (Mandatory)
 # The output file must be an existing .sqlite file
 # For Pefrect Foresight, the user may target the same input file or a separate /
 # copied sqlite file in a different location.  Myopic requires that input_database = output_database
-output_database = "testing_outputs/simple_linked_tech.sqlite"
+output_database = "tests/testing_outputs/simple_linked_tech.sqlite"
 
 # ------------------------------------
 #        DATA / MODEL CHECKS

--- a/tests/testing_configs/config_mediumville.toml
+++ b/tests/testing_configs/config_mediumville.toml
@@ -19,13 +19,13 @@ scenario_mode = "build_only"
 # Input file (Mandatory)
 # Input can be a .sqlite or .dat file
 # Both relative path and absolute path are accepted
-input_database = "testing_outputs/mediumville.sqlite"
+input_database = "tests/testing_outputs/mediumville.sqlite"
 
 # Output file (Mandatory)
 # The output file must be an existing .sqlite file
 # the user may target the same input file or a separate /
 # copied sqlite file in a different location
-output_database = "testing_outputs/mediumville.sqlite"
+output_database = "tests/testing_outputs/mediumville.sqlite"
 
 # ------------------------------------
 #             SOLVER

--- a/tests/testing_configs/config_storageville.toml
+++ b/tests/testing_configs/config_storageville.toml
@@ -19,13 +19,13 @@ scenario_mode = "perfect_foresight"
 # Input file (Mandatory)
 # Input can be a .sqlite or .dat file
 # Both relative path and absolute path are accepted
-input_database = "testing_outputs/storageville.sqlite"
+input_database = "tests/testing_outputs/storageville.sqlite"
 
 # Output file (Mandatory)
 # The output file must be an existing .sqlite file
 # the user may target the same input file or a separate /
 # copied sqlite file in a different location
-output_database = "testing_outputs/storageville.sqlite"
+output_database = "tests/testing_outputs/storageville.sqlite"
 
 # ------------------------------------
 #             SOLVER

--- a/tests/testing_configs/config_test_system.toml
+++ b/tests/testing_configs/config_test_system.toml
@@ -2,8 +2,8 @@
 scenario = "test run"
 scenario_mode = "perfect_foresight"
 
-input_database = "testing_outputs/test_system.sqlite"
-output_database = "testing_outputs/test_system.sqlite"
+input_database = "tests/testing_outputs/test_system.sqlite"
+output_database = "tests/testing_outputs/test_system.sqlite"
 neos = false
 
 # solver

--- a/tests/testing_configs/config_utopia.toml
+++ b/tests/testing_configs/config_utopia.toml
@@ -2,8 +2,8 @@
 scenario = "test run"
 scenario_mode = "perfect_foresight"
 
-input_database = "testing_outputs/utopia.sqlite"
-output_database = "testing_outputs/utopia.sqlite"
+input_database = "tests/testing_outputs/utopia.sqlite"
+output_database = "tests/testing_outputs/utopia.sqlite"
 neos = false
 
 # solver

--- a/tests/testing_configs/config_utopia_myopic.toml
+++ b/tests/testing_configs/config_utopia_myopic.toml
@@ -4,8 +4,8 @@ scenario_mode = "myopic"
 
 # note that myopic currently only supports input = output.  Test code will be responsible
 # for making a fresh copy (if desired) and moving it to the output folder
-input_database = "testing_outputs/myo_utopia.sqlite"
-output_database = "testing_outputs/myo_utopia.sqlite"
+input_database = "tests/testing_outputs/myo_utopia.sqlite"
+output_database = "tests/testing_outputs/myo_utopia.sqlite"
 neos = false
 
 # solver


### PR DESCRIPTION
THIS IS A TEMPORARY IMPLEMENTATION. DO NOT BUILD UPON THIS BRANCH.

Demand processes currently have time slice level flows, satisfying a demand constraint in each time slice. This requires a flow variable and a constraint for every demand process for every output time slice in the model.

Additionally, alternative processes satisfying the same demand must be constrained to prevent over optimisation in time. To prevent, for example, a heat pump from one home and a gas furnace in another home running at different times of the year to heat both homes, depending on relative fuel prices, the demand activity constraint forces each demand process to satisfy the same ratio of end use demand in all time slices. This requires an additional constraint for every demand process and time slice in the model. The net effect of this constraint is simply to conform all demand process outputs to the profile of the DemandSpecificDistribution.

This change instead converts demand processes into annual technologies, so they each have only one annual flow rather than many time slice flows. The demand constraint can then be satisfied only annually, with the upstream commodity balance multiplying this downstream annual flow by its DemandSpecificDistribution. This also eliminates the need for the DemandActivity constraint.

This change considerably reduces the number of constraints and variables in the model, reducing memory requirements and runtimes without changing model results.