### PR TITLE
 using enums for operator expression for simpler and more robust func…

### DIFF
--- a/temoa/components/limits.py
+++ b/temoa/components/limits.py
@@ -18,7 +18,7 @@ from pyomo.environ import Constraint, value
 
 import temoa.components.geography as geography
 import temoa.components.technology as technology
-from temoa.components.utils import get_variable_efficiency, operator_expression
+from temoa.components.utils import Operator, get_variable_efficiency, operator_expression
 
 if TYPE_CHECKING:
     from temoa.core.model import TemoaModel
@@ -259,7 +259,7 @@ def LimitResource_Constraint(M: 'TemoaModel', r, t, op):
     )
 
     resource_lim = value(M.LimitResource[r, t, op])
-    expr = operator_expression(activity, op, resource_lim)
+    expr = operator_expression(activity, Operator(op), resource_lim)
     return expr
 
 
@@ -326,7 +326,7 @@ def LimitActivityShare_Constraint(M: 'TemoaModel', r, p, g1, g2, op):
     )
 
     share_lim = value(M.LimitActivityShare[r, p, g1, g2, op])
-    expr = operator_expression(sub_activity, op, share_lim * super_activity)
+    expr = operator_expression(sub_activity, Operator(op), share_lim * super_activity)
     # in the case that there is nothing to sum, skip
     if isinstance(expr, bool):  # an empty list was generated
         return Constraint.Skip
@@ -366,7 +366,7 @@ def LimitCapacityShare_Constraint(M: 'TemoaModel', r, p, g1, g2, op):
     )
     share_lim = value(M.LimitCapacityShare[r, p, g1, g2, op])
 
-    expr = operator_expression(sub_capacity, op, share_lim * super_capacity)
+    expr = operator_expression(sub_capacity, Operator(op), share_lim * super_capacity)
     if isinstance(expr, bool):
         return Constraint.Skip
     return expr
@@ -397,7 +397,7 @@ def LimitNewCapacityShare_Constraint(M: 'TemoaModel', r, p, g1, g2, op):
     )
 
     share_lim = value(M.LimitNewCapacityShare[r, p, g1, g2, op])
-    expr = operator_expression(sub_new_cap, op, share_lim * super_new_cap)
+    expr = operator_expression(sub_new_cap, Operator(op), share_lim * super_new_cap)
     if isinstance(expr, bool):
         return Constraint.Skip
     return expr
@@ -452,7 +452,7 @@ def LimitAnnualCapacityFactor_Constraint(M: 'TemoaModel', r, p, t, o, op):
         for _r in regions
     )
     annual_cf = value(M.LimitAnnualCapacityFactor[r, p, t, o, op])
-    expr = operator_expression(activity_rpt, op, annual_cf * possible_activity_rpt)
+    expr = operator_expression(activity_rpt, Operator(op), annual_cf * possible_activity_rpt)
     # in the case that there is nothing to sum, skip
     if isinstance(expr, bool):  # an empty list was generated
         return Constraint.Skip
@@ -511,7 +511,7 @@ def LimitSeasonalCapacityFactor_Constraint(M: 'TemoaModel', r, p, s, t, op):
         for _r in regions
     )
     seasonal_cf = value(M.LimitSeasonalCapacityFactor[r, p, s, t, op])
-    expr = operator_expression(activity_rpst, op, seasonal_cf * possible_activity_rpst)
+    expr = operator_expression(activity_rpst, Operator(op), seasonal_cf * possible_activity_rpst)
     # in the case that there is nothing to sum, skip
     if isinstance(expr, bool):  # an empty list was generated
         return Constraint.Skip
@@ -537,7 +537,9 @@ def LimitTechInputSplit_Constraint(M: 'TemoaModel', r, p, s, d, i, t, v, op):
         for S_o in M.processOutputsByInput[r, p, t, v, S_i]
     )
 
-    expr = operator_expression(inp, op, value(M.LimitTechInputSplit[r, p, i, t, op]) * total_inp)
+    expr = operator_expression(
+        inp, Operator(op), value(M.LimitTechInputSplit[r, p, i, t, op]) * total_inp
+    )
     return expr
 
 
@@ -560,12 +562,12 @@ def LimitTechInputSplitAnnual_Constraint(M: 'TemoaModel', r, p, i, t, v, op):
     )
 
     expr = operator_expression(
-        inp, op, value(M.LimitTechInputSplitAnnual[r, p, i, t, op]) * total_inp
+        inp, Operator(op), value(M.LimitTechInputSplitAnnual[r, p, i, t, op]) * total_inp
     )
     return expr
 
 
-def LimitTechInputSplitAverage_Constraint(M: 'TemoaModel', r, p, i, t, v, op):
+def LimitTechInputSplitAverage_Constraint(M: 'TemoaModel', r, p, i, t, v, op: str):
     r"""
     Allows users to limit shares of commodity inputs to a process
     producing a single output. Under this constraint, only the technologies with variable
@@ -592,7 +594,7 @@ def LimitTechInputSplitAverage_Constraint(M: 'TemoaModel', r, p, i, t, v, op):
     )
 
     expr = operator_expression(
-        inp, op, value(M.LimitTechInputSplitAnnual[r, p, i, t, op]) * total_inp
+        inp, Operator(op), value(M.LimitTechInputSplitAnnual[r, p, i, t, op]) * total_inp
     )
     return expr
 
@@ -642,7 +644,9 @@ def LimitTechOutputSplit_Constraint(M: 'TemoaModel', r, p, s, d, t, v, o, op):
         for S_o in M.processOutputsByInput[r, p, t, v, S_i]
     )
 
-    expr = operator_expression(out, op, value(M.LimitTechOutputSplit[r, p, t, o, op]) * total_out)
+    expr = operator_expression(
+        out, Operator(op), value(M.LimitTechOutputSplit[r, p, t, o, op]) * total_out
+    )
     return expr
 
 
@@ -671,7 +675,7 @@ def LimitTechOutputSplitAnnual_Constraint(M: 'TemoaModel', r, p, t, v, o, op):
     )
 
     expr = operator_expression(
-        out, op, value(M.LimitTechOutputSplitAnnual[r, p, t, o, op]) * total_out
+        out, Operator(op), value(M.LimitTechOutputSplitAnnual[r, p, t, o, op]) * total_out
     )
     return expr
 
@@ -701,7 +705,7 @@ def LimitTechOutputSplitAverage_Constraint(M: 'TemoaModel', r, p, t, v, o, op):
     )
 
     expr = operator_expression(
-        out, op, value(M.LimitTechOutputSplitAnnual[r, p, t, o, op]) * total_out
+        out, Operator(op), value(M.LimitTechOutputSplitAnnual[r, p, t, o, op]) * total_out
     )
     return expr
 
@@ -793,7 +797,7 @@ def LimitEmission_Constraint(M: 'TemoaModel', r, p, e, op):
         # + emissions_curtail # NO! curtailed flows are not actual flows, just an accounting tool
         # + emissions_flex_annual # NO! flexannual is subtracted from flowoutannual, already accounted
     )
-    expr = operator_expression(lhs, op, emission_limit)
+    expr = operator_expression(lhs, Operator(op), emission_limit)
 
     # in the case that there is nothing to sum, skip
     if isinstance(expr, bool):  # an empty list was generated
@@ -905,9 +909,9 @@ def LimitGrowthCapacity(M: 'TemoaModel', r, p, t, op, degrowth: bool = False):
         capacity_prev = sum(CapRPT[_r, _p, _t] for _r, _p, _t in cap_rpt if _p == p_prev)
 
     if degrowth:
-        expr = operator_expression(capacity_prev, op, SEED + capacity * RATE)
+        expr = operator_expression(capacity_prev, Operator(op), SEED + capacity * RATE)
     else:
-        expr = operator_expression(capacity, op, SEED + capacity_prev * RATE)
+        expr = operator_expression(capacity, Operator(op), SEED + capacity_prev * RATE)
 
     # Check if any variables are actually included before returning
     if isinstance(expr, bool):
@@ -1014,9 +1018,9 @@ def LimitGrowthNewCapacity(M: 'TemoaModel', r, p, t, op, degrowth: bool = False)
         new_cap_prev = sum(NewCapRTV[_r, _t, _v] for _r, _t, _v in cap_rtv if _v == p_prev)
 
     if degrowth:
-        expr = operator_expression(new_cap_prev, op, SEED + new_cap * RATE)
+        expr = operator_expression(new_cap_prev, Operator(op), SEED + new_cap * RATE)
     else:
-        expr = operator_expression(new_cap, op, SEED + new_cap_prev * RATE)
+        expr = operator_expression(new_cap, Operator(op), SEED + new_cap_prev * RATE)
 
     # Check if any variables are actually included before returning
     if isinstance(expr, bool):
@@ -1148,9 +1152,9 @@ def LimitGrowthNewCapacityDelta(M: 'TemoaModel', r, p, t, op, degrowth: bool = F
     nc_delta = new_cap - new_cap_prev
 
     if degrowth:
-        expr = operator_expression(nc_delta_prev, op, SEED + nc_delta * RATE)
+        expr = operator_expression(nc_delta_prev, Operator(op), SEED + nc_delta * RATE)
     else:
-        expr = operator_expression(nc_delta, op, SEED + nc_delta_prev * RATE)
+        expr = operator_expression(nc_delta, Operator(op), SEED + nc_delta_prev * RATE)
 
     # Check if any variables are actually included before returning
     if isinstance(expr, bool):
@@ -1209,7 +1213,7 @@ def LimitActivity_Constraint(M: 'TemoaModel', r, p, t, op):
     )
 
     act_lim = value(M.LimitActivity[r, p, t, op])
-    expr = operator_expression(activity, op, act_lim)
+    expr = operator_expression(activity, Operator(op), act_lim)
     # in the case that there is nothing to sum, skip
     if isinstance(expr, bool):  # an empty list was generated
         return Constraint.Skip
@@ -1233,7 +1237,7 @@ def LimitNewCapacity_Constraint(M: 'TemoaModel', r, p, t, op):
     techs = technology.gather_group_techs(M, t)
     cap_lim = value(M.LimitNewCapacity[r, p, t, op])
     new_cap = sum(M.V_NewCapacity[_r, _t, p] for _t in techs for _r in regions)
-    expr = operator_expression(new_cap, op, cap_lim)
+    expr = operator_expression(new_cap, Operator(op), cap_lim)
     return expr
 
 
@@ -1256,7 +1260,7 @@ def LimitCapacity_Constraint(M: 'TemoaModel', r, p, t, op):
     capacity = sum(
         M.V_CapacityAvailableByPeriodAndTech[_r, p, _t] for _t in techs for _r in regions
     )
-    expr = operator_expression(capacity, op, cap_lim)
+    expr = operator_expression(capacity, Operator(op), cap_lim)
     return expr
 
 

--- a/temoa/components/storage.py
+++ b/temoa/components/storage.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from pyomo.environ import Constraint, value
 
-from .utils import get_variable_efficiency, operator_expression
+from .utils import Operator, get_variable_efficiency, operator_expression
 
 if TYPE_CHECKING:
     from temoa.core.model import TemoaModel
@@ -487,6 +487,6 @@ def LimitStorageFraction_Constraint(M: 'TemoaModel', r, p, s, d, t, v, op):
             M.TimeSeasonSequential[p, s_seq, s]
         )
 
-    expr = operator_expression(energy_level, op, energy_limit)
+    expr = operator_expression(energy_level, Operator(op), energy_limit)
 
     return expr

--- a/temoa/components/utils.py
+++ b/temoa/components/utils.py
@@ -6,6 +6,7 @@ These helpers are used by various components to perform common tasks like
 building Pyomo expressions from strings or calculating time-variable efficiencies.
 """
 
+from enum import Enum
 from logging import getLogger
 from typing import TYPE_CHECKING
 
@@ -19,37 +20,21 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 
-def operator_expression(lhs: Expression | None, operator: str | None, rhs: Expression | None):
-    """Returns an expression, applying a configured operator"""
-    if any((lhs is None, operator is None, rhs is None)):
-        msg = ('Tried to build a constraint using a bad expression or operator: {} {} {}').format(
-            lhs, operator, rhs
-        )
-        logger.error(msg)
-        raise ValueError(msg)
-    try:
-        match operator:
-            case 'e':
-                expr = lhs == rhs
-            case 'le':
-                expr = lhs <= rhs
-            case 'ge':
-                expr = lhs >= rhs
-            case _:
-                msg = (
-                    'Tried to build a constraint using a bad operator. Allowed operators are "e","le", or "ge". Got "{}": {} {} {}'
-                ).format(operator, lhs, operator, rhs)
-                logger.error(msg)
-                raise ValueError(msg)
-    except Exception as e:
-        print(e)
-        msg = ('Tried to build a constraint using a bad expression or operator: {} {} {}').format(
-            lhs, operator, rhs
-        )
-        logger.error(msg)
-        raise ValueError(msg) from e
+class Operator(str, Enum):
+    EQUAL = 'e'
+    LESS_EQUAL = 'le'
+    GREATER_EQUAL = 'ge'
 
-    return expr
+
+def operator_expression(lhs: Expression, operator: Operator, rhs: Expression):
+    match operator:
+        case Operator.EQUAL:
+            return lhs == rhs
+        case Operator.LESS_EQUAL:
+            return lhs <= rhs
+        case Operator.GREATER_EQUAL:
+            return lhs >= rhs
+    raise ValueError(f'Invalid operator: {operator!r}')
 
 
 def get_variable_efficiency(M: 'TemoaModel', r, p, s, d, i, t, v, o) -> float:


### PR DESCRIPTION
Using enums for the operator expression utility to make it more robust and harder to make typos with.

Currently wrapping every call with Operator, maybe there is a better place to transform the operators first, but haven't figured out where yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Replaced string-based operators with a typed operator enum and direct operator-to-expression mapping for more consistent constraint handling.

- Chores
  - Updated internal usages to rely on the new operator enum; runtime behavior for constraints is unchanged for most users.

- Note for Integrators
  - One public parameter now has an explicit type annotation; callers may need to supply the typed operator form (enum) instead of raw strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->