### PR TITLE
Fix lifetime check in db migrator to include existing vintages

### DIFF
--- a/temoa/utilities/db_migration_v3_to_v3_1.py
+++ b/temoa/utilities/db_migration_v3_to_v3_1.py
@@ -248,9 +248,10 @@ for old_name, new_name in direct_transfer_tables:
     con_new.executemany(query, data)
     print(f'Transfered {len(data)} rows from {old_name} to {new_name}')
 
-# Need all valid time periods to check for defined lifetimes
-time_all = sorted(cur.execute('SELECT period FROM TimePeriod').fetchall())
-time_all = [p[0] for p in time_all[0:-1]] # Exclude horizon end
+time_all = [
+    p[0] for p in cur.execute('SELECT period FROM TimePeriod').fetchall()
+]
+time_all = sorted(time_all)[0:-1] # Exclude horizon end
 
 # get lifetimes. Major headache but needs to be done
 lifetime_process = dict()
@@ -265,8 +266,11 @@ data = cur.execute('SELECT region, tech, vintage, lifetime FROM LifetimeProcess'
 for rtvl in data:
     lifetime_process[rtvl[0:3]] = rtvl[3]
 
-# Planning periods to add to period indices (less horizon end)
-time_optimize = sorted(cur.execute('SELECT period FROM TimePeriod WHERE flag == "f"').fetchall())[0:-1]
+# Planning periods to add to period indices
+time_optimize = [
+    p[0] for p in cur.execute('SELECT period FROM TimePeriod WHERE flag == "f"').fetchall()
+]
+time_optimize = sorted(time_optimize)[0:-1] # Exclude horizon end
 
 # add period indexing to seasonal tables
 print('\n --- Adding period index to some tables ---')


### PR DESCRIPTION
This section of the migrator accumulates process lifetimes to check, when adding a period index, if that period is relevant to that process. It was only collecting lifetimes for new capacity, and so was assuming the default lifetime (40y) for existing capacity. This fix now checks defined lifetimes for existing capacity as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected migration period selection to use the full sorted timeline (excluding the final boundary) instead of a narrower flagged subset, improving lifetime assignment accuracy and preserving correct period indexing.

* **Refactor**
  * Simplified period handling by separating full-period iteration from the horizon-excluded subset used for indexing, yielding more consistent, deterministic migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->