### PR TITLE
Move gurobipy dependency from core to optional solver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "networkx>=3.3",
     "highspy>=1.7.2",
     "scipy>=1.14.1",
-    "gurobipy>=11.0.3",
     "nx-vis-visualizer>=0.1.1",
     "gravis>=0.1.0",
 ]
@@ -41,7 +40,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "gurobipy>=12.0.3",
     "types-deprecated>=1.2.15.20250304",
     "ruff>=0.2.0",
     "mypy>=1.0.0",
@@ -63,6 +61,9 @@ docs = [
 plotting = [
     "matplotlib>=3.9.2",
     "seaborn>=0.13.2",
+]
+solver = [
+    "gurobipy>=12.0.3,<13",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,8 +80,6 @@ gravis==0.1.0
     # via temoa (pyproject.toml)
 greenlet==3.2.3
     # via sqlalchemy
-gurobipy==12.0.3
-    # via temoa (pyproject.toml)
 h11==0.16.0
     # via httpcore
 h2==4.2.0

--- a/uv.lock
+++ b/uv.lock
@@ -2943,7 +2943,6 @@ dependencies = [
     { name = "deprecated" },
     { name = "graphviz" },
     { name = "gravis" },
-    { name = "gurobipy" },
     { name = "highspy" },
     { name = "ipykernel" },
     { name = "ipython" },
@@ -2980,10 +2979,12 @@ plotting = [
     { name = "matplotlib" },
     { name = "seaborn" },
 ]
+solver = [
+    { name = "gurobipy" },
+]
 
 [package.dev-dependencies]
 dev = [
-    { name = "gurobipy" },
     { name = "mypy" },
     { name = "pandas-stubs" },
     { name = "pre-commit" },
@@ -2998,7 +2999,7 @@ requires-dist = [
     { name = "deprecated", specifier = ">=1.2.14" },
     { name = "graphviz", specifier = ">=0.20.3" },
     { name = "gravis", specifier = ">=0.1.0" },
-    { name = "gurobipy", specifier = ">=11.0.3" },
+    { name = "gurobipy", marker = "extra == 'solver'", specifier = ">=12.0.3,<13" },
     { name = "highspy", specifier = ">=1.7.2" },
     { name = "ipykernel" },
     { name = "ipython" },
@@ -3029,11 +3030,10 @@ requires-dist = [
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "xlsxwriter", specifier = ">=3.2.0" },
 ]
-provides-extras = ["docs", "plotting"]
+provides-extras = ["docs", "plotting", "solver"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "gurobipy", specifier = ">=12.0.3" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "pandas-stubs", specifier = ">=2.3.2.250926" },
     { name = "pre-commit" },


### PR DESCRIPTION
Closing #167 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved the Gurobi solver out of default installation and made it an optional "solver" extra. Default installs are smaller; users who require solver functionality should install the optional solver extra or add the solver package separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->