### PR TITLE
Removing gurobipy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,7 @@ plotting = [
     "matplotlib>=3.9.2",
     "seaborn>=0.13.2",
 ]
-solver = [
-    "gurobipy>=12.0.3,<13",
-]
+solver = []
 
 [build-system]
 requires = ["hatchling"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,8 +30,6 @@ fonttools==4.59.0
     # via matplotlib
 graphviz==0.21
     # via temoa (pyproject.toml)
-gurobipy==12.0.3
-    # via temoa (pyproject.toml)
 highspy==1.11.0
     # via temoa (pyproject.toml)
 idna==3.10

--- a/uv.lock
+++ b/uv.lock
@@ -278,21 +278,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gurobipy"
-version = "12.0.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/bb/b3784497115c64c2bd122cc9d411f167026d4ec42a26b1ff3c43a779275d/gurobipy-12.0.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:020f23277f630e079eac114385eabd1bd9fb4ac22f8796ed5ba6d915ce4f141b", size = 12222234, upload-time = "2025-07-15T07:19:24.64Z" },
-    { url = "https://files.pythonhosted.org/packages/18/ea/c065984de5287c99fd30ee8d700fd78f83692e992471f9667ab5d36612b9/gurobipy-12.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:72bbf544bc05060bb93909b79715ace4c0f416198f7622a985cabb9e8e99aa1c", size = 62583866, upload-time = "2025-07-15T07:20:17.576Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/8b/2b9f26e4e19a258229b8a8ffc377ca372cc2059a22a0a7c67572efe308d8/gurobipy-12.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b3f971caf270f671b6ffcf5b937b3c0430a5264b0f01529dc8681d61c221f215", size = 14268480, upload-time = "2025-07-15T07:20:26.898Z" },
-    { url = "https://files.pythonhosted.org/packages/26/0f/3544a323635f37cdfe1e011d2903b7ef94ba18e10224fa1419f64d0c1968/gurobipy-12.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:af18fd03d5dc3f6e5f590c372ad288b8430a6d88a5b5e66cfcd8432f86ee8650", size = 11121565, upload-time = "2025-07-15T07:20:34.576Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/95/f0e5b5cf85298f42482cf4e53d8114c45bb962f55195d531fe4e62b5afa1/gurobipy-12.0.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a8552e47673cb6f1fd351edf8fcad86b02f832cbfb57d90ef21e0397e96d138e", size = 12183439, upload-time = "2025-07-15T07:20:44.224Z" },
-    { url = "https://files.pythonhosted.org/packages/61/6e/aea725b4143faa4eb6878414a91fa74e7871aba0ab9453803a9eeef781c2/gurobipy-12.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:be05c074141c8a126c8aaeccc41795ab091a666eabb39ca1ff98a74bde81e663", size = 62583451, upload-time = "2025-07-15T07:21:38.825Z" },
-    { url = "https://files.pythonhosted.org/packages/75/47/7b9c63ce2cd85d796403b91a6d211d5c8baac7b694edd94e2151f365d6a9/gurobipy-12.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:79a333766e27fef7902ceeefbcf0279a1ca393a27a72ea62f8e301b21aa17d59", size = 14271076, upload-time = "2025-07-15T07:21:55.102Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/93/b10cd6112c05675fed5c817fd7933c9d4ba3a7039e42cba844a9ac09242a/gurobipy-12.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:e0f9ed55077e622021369bb9df2ca3b00c86b678792a3b1556cc59f67348fab0", size = 11111414, upload-time = "2025-07-15T07:22:05.079Z" },
-]
-
-[[package]]
 name = "highspy"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1342,9 +1327,6 @@ plotting = [
     { name = "matplotlib" },
     { name = "seaborn" },
 ]
-solver = [
-    { name = "gurobipy" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -1362,7 +1344,6 @@ dev = [
 requires-dist = [
     { name = "deprecated", specifier = ">=1.2.14" },
     { name = "graphviz", specifier = ">=0.20.3" },
-    { name = "gurobipy", marker = "extra == 'solver'", specifier = ">=12.0.3,<13" },
     { name = "highspy", specifier = ">=1.7.2" },
     { name = "joblib" },
     { name = "matplotlib", specifier = "==3.9.2" },


### PR DESCRIPTION
the gurobipy dependency is not needed by the code, users that want to use the solver can download it separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the external solver dependency from project configuration and development requirements, simplifying installation and reducing external tooling needed.
  * Updated public configuration to reflect no default solver declared.
  * No other runtime behavior changes; remaining dependencies unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->