### PR TITLE
Sync main to unstable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.13
+    rev: 0.11.14
     hooks:
       # Dependency management
       - id: uv-lock
@@ -47,7 +47,7 @@ repos:
     # Python Linting & Formatting with Ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.15.12"
+    rev: "v0.15.13"
     hooks:
       - id: ruff
         name: ruff (linter)


### PR DESCRIPTION
Passing through updates from pre-commit ci done on the main branch to the unstable branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tool versions: `uv-pre-commit` to `0.11.14` and `ruff-pre-commit` to `v0.15.13`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TemoaProject/temoa/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->