### PR TITLE
clean incomplete emissions constraint handler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.19
+    rev: 0.11.21
     hooks:
       # Dependency management
       - id: uv-lock
@@ -47,7 +47,7 @@ repos:
     # Python Linting & Formatting with Ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.15.16"
+    rev: "v0.15.17"
     hooks:
       - id: ruff
         name: ruff (linter)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.21
+    rev: 0.11.23
     hooks:
       # Dependency management
       - id: uv-lock
@@ -47,7 +47,7 @@ repos:
     # Python Linting & Formatting with Ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.15.17"
+    rev: "v0.15.18"
     hooks:
       - id: ruff
         name: ruff (linter)

--- a/temoa/components/limits.py
+++ b/temoa/components/limits.py
@@ -941,7 +941,7 @@ def limit_emission_constraint(
     # in the case that there is nothing to sum, skip
     if isinstance(expr, bool):  # an empty list was generated
         msg = "Warning: No technology produces emission '%s', though limit was specified as %s.\n"
-        logger.warning(msg, (e, emission_limit))
+        logger.warning(msg % (e, emission_limit))
         sys.stderr.write(msg % (e, emission_limit))
         return Constraint.Skip
 

--- a/temoa/components/limits.py
+++ b/temoa/components/limits.py
@@ -941,7 +941,7 @@ def limit_emission_constraint(
     # in the case that there is nothing to sum, skip
     if isinstance(expr, bool):  # an empty list was generated
         msg = "Warning: No technology produces emission '%s', though limit was specified as %s.\n"
-        logger.warning(msg % (e, emission_limit))
+        logger.warning(msg, e, emission_limit)
         sys.stderr.write(msg % (e, emission_limit))
         return Constraint.Skip
 


### PR DESCRIPTION
fixing bug #331

we've got
` msg = "Warning: No technology produces emission '%s', though limit was specified as %s.\n" `
`logger.warning(msg, (e, emission_limit))`

it's a 1 character fix. We want to pre-format the message string before feeding it to `logger.warning`. 

`logger.warning(msg, (e, emission_limit))` forces python to do the formatting, but it will make a 1-tuple of our 2-tuple: `((e, emission_limit),)` and thus the `msg` pre-formatted string will ask for two things from the 1-tuple and crash with a `TypeError`

`logger.warning(msg %(e, emission_limit))`  explicitly gives `msg` the elements it wants. Then `logger.warning` doesn't mess with our tuple, it just sees a nice clean string with the values of `e` and `emission_limit` already incorporated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved formatting of warning messages emitted during emission limit validation so placeholders are populated correctly.
  * No functional behavior changes; this yields clearer runtime warnings and more reliable diagnostic messages for operators and maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->