### PR TITLE
Change overaggressive error to warning in check_existing_capacity

### DIFF
--- a/temoa/components/technology.py
+++ b/temoa/components/technology.py
@@ -430,8 +430,7 @@ def check_existing_capacity(model: TemoaModel) -> None:
         if (r, t, v) not in model.process_periods and v + life > model.time_optimize.first():
             msg = (
                 f'Existing capacity {r, t, v} with lifetime {life} and capacity {cap} '
-                'should extend into future periods but it is not in process periods. '
+                'should extend into future periods but it is not a valid process. '
                 'Was it included in the Efficiency table?'
             )
-            logger.error(msg)
-            raise ValueError(msg)
+            logger.warning(msg)


### PR DESCRIPTION
As the myopic sequencer moves forward, it checks whether previously built capacity survived thus far. If any existing capacity is not seen in the previous period's net capacity output (e.g., was retired early, or survival curved down under the threshold) then that process is removed from the myopic efficiency table and therefore is no longer a valid process going forward.

HOWEVER, these are still pulled into the existing capacity parameter for accounting purposes. This all works out fine except that I had previously put in a check that will not-so-helpfully tell users that their existing capacity should be a valid process but isn't (because previous myopic horizons decided to retire it early) then raise a ValueError and crash the run.

Changing this error to a warning fixes the issue. In perfect foresight, this should always be a bug but not necessarily a deadly bug so a warning should cover that anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for capacity entries with lifetimes extending into future periods. The system now logs a warning and continues operation instead of halting with an error, allowing workflows to proceed more smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->