### PR TITLE
chore: reconcile version drift, bump to 4.0.1

### DIFF
--- a/temoa/__about__.py
+++ b/temoa/__about__.py
@@ -1,6 +1,6 @@
 import re
 
-__version__ = '4.0.0a2'
+__version__ = '4.0.0'
 
 # Parse the version string to get major and minor versions
 # We use a regex to be robust against versions like "4.1a1" or "4.0.0.dev1"

--- a/temoa/__about__.py
+++ b/temoa/__about__.py
@@ -1,6 +1,6 @@
 import re
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 
 # Parse the version string to get major and minor versions
 # We use a regex to be robust against versions like "4.1a1" or "4.0.0.dev1"


### PR DESCRIPTION
main was missing the 4.0.0 release version-bump commit (0d1d00e2); this restores it and bumps to 4.0.1 for the dependency-security patch release in #<Step 1 PR number>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 4.0.1.
  - Promoted the release from an alpha build to a stable patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->