### PR TITLE
Fix MILP solver parameters: remove LP-tuned custom solver options

### DIFF
--- a/temoa/_internal/run_actions.py
+++ b/temoa/_internal/run_actions.py
@@ -202,24 +202,32 @@ def solve_instance(
         raise NotImplementedError('Neos based solve is not currently supported')
 
     # Solver Configuration
+    #
+    # Note: no custom solver options are set here.  We deliberately let every solver
+    # run with its own default settings so that models are solved correctly regardless
+    # of whether they are pure LPs or MILPs (integer extensions).
+    #
+    # The LP-tuned options that used to live here (barrier method, crossover disabled,
+    # and loose barrier/feasibility tolerances, matching mip-dev / PyPSA) could crash
+    # MIP solves and produce inappropriate tolerances for integer problems.  They were
+    # removed to keep MILP solves robust.  For reference, the previous values were:
+    #
+    #   cplex:  lpmethod=4 (barrier), solutiontype=2 (no crossover),
+    #           'barrier convergetol'=1.0e-3, 'feasopt tolerance'=1.0e-4
+    #   gurobi: Method=2 (barrier), Crossover=0 (no crossover),
+    #           BarConvTol=1.0e-3, FeasibilityTol=1.0e-4, BarOrder=-1 (auto)
+    #   (see: https://pypsa-eur.readthedocs.io/en/latest/configuration.html)
+    #
+    # Users who need to tune solver performance for large LPs should set options
+    # explicitly (e.g. via the *_solver_options.toml files used by the extensions).
     if solver_name == 'cbc':
         pass
 
     elif solver_name == 'cplex':
-        # Note: these parameter values match mip-dev / PyPSA
-        # (see: https://pypsa-eur.readthedocs.io/en/latest/configuration.html)
-        optimizer.options['lpmethod'] = 4  # barrier
-        optimizer.options['solutiontype'] = 2  # non basic solution, ie no crossover
-        optimizer.options['barrier convergetol'] = 1.0e-3
-        optimizer.options['feasopt tolerance'] = 1.0e-4
+        pass
 
     elif solver_name == 'gurobi':
-        # Note: these parameter values match mip-dev / PyPSA (see: https://pypsa-eur.readthedocs.io/en/latest/configuration.html)
-        optimizer.options['Method'] = 2  # barrier
-        optimizer.options['Crossover'] = 0  # non basic solution, ie no crossover
-        optimizer.options['BarConvTol'] = 1.0e-3
-        optimizer.options['FeasibilityTol'] = 1.0e-4
-        optimizer.options['BarOrder'] = -1  # auto ordering; 2-4x faster than AMD on large models
+        pass
 
     elif solver_name == 'appsi_highs':
         pass


### PR DESCRIPTION
Removed the custom solver options for CPLEX and Gurobi in temoa/_internal/run_actions.py. All solvers now run with their default settings.

The previous options were tuned for LPs and cause problems once the integer (MILP) extensions are activated: disabling crossover can crash MIP solves, and the loose barrier/feasibility tolerances are not appropriate for integer solves. Per the maintainers' recommendation, the safest fix is to drop these custom options and let each solver choose settings appropriate to the problem type (LP or MILP).

The previous LP-tuned values (matching mip-dev / PyPSA) are kept as an inline reference comment so advanced users can re-tune LP performance if needed, e.g. via the extensions' *_solver_options.toml files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified solver configuration by removing automatic, solver-specific tuning options.
  - Preserved the existing solve workflow, validation, error handling, and optimal-result checks.
  - Solver behavior may now rely more on each solver’s default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->